### PR TITLE
Issue#1

### DIFF
--- a/boot/32bit-gdt.asm
+++ b/boot/32bit-gdt.asm
@@ -1,0 +1,35 @@
+gdt_start: ; don't remove the labels, they're needed to compute sizes and jumps
+    ; the GDT starts with a null 8-byte
+    dd 0x0 ; 4 byte
+    dd 0x0 ; 4 byte
+
+; GDT for code segment. base = 0x00000000, length = 0xfffff
+; for flags, refer to os-dev.pdf document, page 36
+gdt_code: 
+    dw 0xffff    ; segment length, bits 0-15
+    dw 0x0       ; segment base, bits 0-15
+    db 0x0       ; segment base, bits 16-23
+    db 10011010b ; flags (8 bits)
+    db 11001111b ; flags (4 bits) + segment length, bits 16-19
+    db 0x0       ; segment base, bits 24-31
+
+; GDT for data segment. base and length identical to code segment
+; some flags changed, again, refer to os-dev.pdf
+gdt_data:
+    dw 0xffff
+    dw 0x0
+    db 0x0
+    db 10010010b
+    db 11001111b
+    db 0x0
+
+gdt_end:
+
+; GDT descriptor
+gdt_descriptor:
+    dw gdt_end - gdt_start - 1 ; size (16 bit), always one less of its true size
+    dd gdt_start ; address (32 bit)
+
+; define some constants for later use
+CODE_SEG equ gdt_code - gdt_start
+DATA_SEG equ gdt_data - gdt_start

--- a/boot/32bit-main.asm
+++ b/boot/32bit-main.asm
@@ -1,0 +1,29 @@
+[org 0x7c00]
+	mov bp, 0x9000
+	mov sp, bp
+
+	mov dx, MSG_REAL_MODE
+	call print_string
+
+	call switch_to_pm
+
+	jmp $
+
+%include "print.asm"
+%include "32bit-gdt.asm"
+%include "32bit-switch.asm"
+
+[bits 32]
+
+BEGIN_PM:
+	mov ebx, MSG_PROT_MODE
+	call print_string_pm
+
+	jmp $
+
+MSG_REAL_MODE db "Started in 16-bit Real Mode", 0
+MSG_PROT_MODE db "Successfully landed in 32 bit protected mode", 0
+
+times 510-($-$$) db 0
+dw 0xaa55
+

--- a/boot/32bit-switch.asm
+++ b/boot/32bit-switch.asm
@@ -1,0 +1,23 @@
+[bits 16]
+
+switch_to_pm:
+	cli
+	lgdt [gdt_descriptor]
+	mov eax, cr0
+	or eax, 0x1
+	mov cr0, eax
+	jmp CODE_SEG:init_pm
+
+[bits 32]
+init_pm:
+	mov ax, DATA_SEG
+	mov ds, ax
+	mov ss, ax
+	mov es, ax
+	mov fs, ax
+	mov gs, ax
+
+	mov ebp, 0x90000
+	mov esp, ebp
+
+	call BEGIN_PM

--- a/boot/print.asm
+++ b/boot/print.asm
@@ -1,0 +1,66 @@
+print_hex:
+    pusha
+    mov cx, 0x00
+print_hex_loop:
+    cmp cx, 0x04
+    je print_hex_print_data
+    mov ax, dx
+    and ax, 0x000f
+    cmp ax, 0x0a
+    jl print_hex_convert_to_numeral
+print_hex_convert_to_alpha:
+        add ax, 0x57
+        jmp print_hex_copy_data
+print_hex_convert_to_numeral:
+        add ax, 0x30
+print_hex_copy_data:
+        mov bx, HEX_MSG
+        add bx, 0x05
+        sub bx, cx
+        mov [bx], al
+    shr dx, 4
+    add cx, 0x01
+    jmp print_hex_loop
+print_hex_print_data:
+    mov dx, HEX_MSG
+    call print_string
+print_hex_exit:
+    popa
+    ret
+
+HEX_MSG: db "0x0000", 0
+
+print_string:
+    pusha
+    mov bx, dx
+    mov ah, 0x0e
+print_string_loop:
+    mov al, [bx]
+    cmp al, 0x00
+    je print_string_exit
+    int 0x10
+    add bx, 0x01
+    jmp print_string_loop
+print_string_exit:
+    popa
+    ret
+
+[bits 32]
+VIDEO_MEMORY equ 0xb8000
+WHITE_ON_BLACK equ 0x0f
+
+print_string_pm:
+    pusha
+    mov edx, VIDEO_MEMORY
+print_string_pm_loop:
+    mov al, [ebx]
+    cmp al, 0
+    je print_strint_pm_exit
+    mov ah, WHITE_ON_BLACK
+    mov [edx], ax
+    add edx, 0x02
+    add ebx, 0x01
+    jmp print_string_pm_loop
+print_strint_pm_exit:
+    popa
+    ret

--- a/boot/read_disk.asm
+++ b/boot/read_disk.asm
@@ -1,0 +1,26 @@
+disk_load:
+	pusha
+	push dx
+	mov ah, 0x02
+	mov al, dh
+	mov ch, 0x00
+	mov cl, 0x02
+	mov dh, 0x00
+	int 0x13
+	jc disk_error
+	pop dx
+	cmp al, dh
+	jne disk_sector_error
+	popa
+	ret
+disk_error:
+	mov dx, DISK_ERROR_MSG
+	call print_string
+	jmp $
+disk_sector_error:
+	mov dx, DISK_SECTOR_ERROR_MSG
+	call print_string
+	jmp $
+
+DISK_ERROR_MSG: db "Disk read error", 0
+DISK_SECTOR_ERROR_MSG: db "Incorrect sectors read", 0

--- a/boot/read_disk_main.asm
+++ b/boot/read_disk_main.asm
@@ -1,0 +1,28 @@
+[org 0x7c00]
+	mov [BOOT_DRIVE], dl
+	mov bp, 0x8000
+	mov sp, bp
+
+	mov bx, 0x9000
+	mov dh, 0x02
+	mov dl, [BOOT_DRIVE]
+	call disk_load
+
+	mov dx, [0x9000]
+	call print_hex
+
+	mov dx, [0x9000 + 512]
+	call print_hex
+
+	jmp $
+
+%include "print.asm"
+%include "read_disk.asm"
+
+BOOT_DRIVE: db 0
+MSG: db "Debug", 0
+times 510 - ($ - $$) db 0
+dw 0xaa55
+
+times 256 dw 0xabcd
+times 256 dw 0x3456


### PR DESCRIPTION
Make minimalOS boot into 32 bit protected mode
without GRUB.
Close #1 .

+ 32bit-gdt.asm:  Assembly for Global Descriptor Table.
		  Defines the simplest of GDTs with
		  overloapping code and data segment.
+ 32bit-main.asm: The main routine to boot into 32-bit
		  protected mode.
+ 32bit-switch.asm : Routine to actually perform the switchover.
+ print.asm	   : Set of assembly routines to print stuff to
		     screen.
+ read_disk.asm	   : Routine to read from the disk.
+ read_disk_main.asm : Driver routine for read_disk.asm