### PR TITLE
feature: bootsrap kernel code.

### DIFF
--- a/boot/bootstrap_kernel.asm
+++ b/boot/bootstrap_kernel.asm
@@ -1,0 +1,43 @@
+[org 0x7c00]
+KERNELOFFSET equ 0x1000
+    mov [BOOT_DRIVE], dl
+
+    mov bp, 0x9000
+    mov sp, bp
+
+    mov dx, MSGRM
+    call print_string
+
+    mov dx, MSG_LOAD_KERNEL
+    call print_string
+
+    mov bx, KERNELOFFSET
+    mov dh, 15
+    mov dl, [BOOT_DRIVE]
+    call disk_load
+
+    call switch_to_pm
+
+    jmp $
+
+%include "print.asm"
+%include "32bit-switch.asm"
+%include "32bit-gdt.asm"
+%include "read_disk.asm"
+
+[bits 32]
+BEGIN_PM:
+    mov ebx, MSG_PROT_MODE
+    call print_string_pm
+
+    call KERNELOFFSET
+
+jmp $
+
+BOOT_DRIVE: db 0
+MSGRM:      db "Started in 16-bit Real Mode", 0
+MSG_PROT_MODE:  db "Successfully landed in 32-bit Protected Mode", 0
+MSG_LOAD_KERNEL: db "Loading kernel into memory", 0
+
+times 510 - ($ - $$) db 0
+dw 0xaa55

--- a/boot/kernel_entry.asm
+++ b/boot/kernel_entry.asm
@@ -1,0 +1,7 @@
+global _start
+[bits 32]
+_start:
+	[extern kernel_main]
+	call kernel_main
+	jmp $
+

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -1,0 +1,5 @@
+void kernel_main(void)
+{
+	char *video_memory = (char*) 0xb8000;
+	*video_memory = 'X';
+}


### PR DESCRIPTION
Bootstrap kernel code written in C.
Closes #6 .

+ bootstrap_kernel.asm : This routine does the following
		- Boot the Operating System
		- Loads the kernel code into memory.
		- Switch to 32 bit protected mode.
		- call the kernel code.
+ kernel_entry.asm : This routine calls the kernel_main
		     method in kernel.c
+ kernel.c	: Contains a simple routine to print
		  a character to the video memory.